### PR TITLE
bug 1801122: update rust-minidump to 7faf03c5

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,10 +14,9 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-# This is 0.14.0.
-# MINIDUMPREV=f9933c36c5f48bf806a428b06399242e1b170020
-MINIDUMPREV=f9933c36
-MINIDUMPREVDATE=2022-08-30
+# This is after 0.14.0 but before 0.15.0.
+MINIDUMPREV=7faf03c5
+MINIDUMPREVDATE=2022-11-17
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 

--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -25,7 +25,7 @@ TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 rustc -vV
 
 # Build the specific version we want of minidump-stackwalk
-echo ">>> compiling minidump-stackwalk ..."
+echo ">>> compiling minidump-stackwalk sha ${MINIDUMPREV} ${MINIDUMPREVDATE} ..."
 cargo install --locked \
     --target=x86_64-unknown-linux-gnu \
     --root=./build/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/rust/
-FROM rust:1.63.0-bullseye@sha256:4d6b7664f5292cdfbeaa7eb9f1f4eae01aa289a49e4f043cdf6f4f63d0cf8ca8
+FROM rust:1.65.0-bullseye@sha256:6c20d87766142d058f3e21874fe1db426c49ce3e1575c8c300fdc27d06db92a9
 
 ARG groupid=10001
 ARG userid=10001


### PR DESCRIPTION
Changes between 0.14.0 and 7faf03c5 (pre-0.15.0):

```    
0aec5ef update indicatif now that a working version is published
dc8deb2 Improve printing of hexadecimal values
048c10a Improvements to Windows error codes printouts
c796d07 Added macOS ARM arithmetic exceptions
2d78f05 Fixed macOS ARM breakpoint and bad access exceptions and added missing ones
6aaf36a Added perma-links to Apple's sources holding the exceptions' declarations
cb7b25c Add instruction disassembly and access to JSON output
3ee32fc Properly report non-canonical addresses on Amd64 architecture
c06fd69 Remove MemoryListCursor and associated trait machinery
d64fb49 Add info about crashing instruction to output
134675e Refactor crash information into its own structure
dfcfac5 Implement op_analysis::SparseMemoryStream for memory lists
ab7fc08 Add instruction analysis for amd64
a6a486b post-release fixup
```