### PR TITLE
bug 1803385: Update to rust-minidump 0.15.0

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -15,8 +15,8 @@ set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
 # This is after 0.14.0 but before 0.15.0.
-MINIDUMPREV=7faf03c5
-MINIDUMPREVDATE=2022-11-17
+MINIDUMPREV=v0.15.0
+MINIDUMPREVDATE=2022-11-30
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 


### PR DESCRIPTION
```
2df6521 (HEAD -> main, tag: v0.15.0, official/main) chore: Release
cd2a736 Update configuration for cargo release 0.22+ and add release notes
a5196a5 Appease clippy
8d7f96e Updated the dependencies
1a456a1 Merge pull request #744 from ePirat/epirat-fix-markdown-help-instructions
f04ecf5 Merge pull request #745 from ePirat/epirat-fix-cargo-release
3e3db7f Merge pull request #742 from ePirat/epirat-fix-parsing-empty-lines-symfile
00292ab Fix cargo-release replacements
66975e6 fix documentation how to generated markdown help
f5f0696 Add empty line in symbol file test
efe2fa0 Add support for empty lines to symbol file parser
```