### PR TITLE
bug 1827416: update stackwalker to v0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ export
 APP_UID ?= 10001
 APP_GID ?= 10001
 
-DC := $(shell which docker-compose)
+DOCKER := $(shell which docker)
+DC=${DOCKER} compose
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,9 +14,8 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-# This is after 0.14.0 but before 0.15.0.
-MINIDUMPREV=v0.15.0
-MINIDUMPREVDATE=2022-11-30
+MINIDUMPREV=v0.16.0
+MINIDUMPREVDATE=2023-04-27
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 ---
-# docker-compose for Socorro development.
-#
-# Note: Requires docker-comopse 1.10+.
 version: "2"
 services:
-  # Socorro app image
   app:
     build:
       context: .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/rust/
-FROM rust:1.65.0-bullseye@sha256:6c20d87766142d058f3e21874fe1db426c49ce3e1575c8c300fdc27d06db92a9
+FROM rust:1.69.0-bullseye@sha256:0996206db384a076bbd96411eb738047b1d978d41e0184cb5ebcb37edf988362
 
 ARG groupid=10001
 ARG userid=10001


### PR DESCRIPTION
This updates the stackwalker to v0.16.0 and also updates Rust to 1.69.0.
