### PR TITLE
bug 1746940: update stackwalker to 3819edf (past v0.18.0)

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,8 +14,9 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-MINIDUMPREV=v0.18.0
-MINIDUMPREVDATE=2023-09-18
+# NOTE(willkg): This is just a bit after v0.18.0.
+MINIDUMPREV=3819edf
+MINIDUMPREVDATE=2023-10-12
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 


### PR DESCRIPTION
This updates the stackwalker to a commit that's v0.18.0 plus the fix for the codeinfo lookup (bug #1746940).