### PR TITLE
bug-1862730: update stackwalker to v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ To regression test changes:
    $ ./bin/generate_regression_data.py crashids.txt
    ```
 
+   This takes 30-40 minutes to run.
+
 4. Make the changes to the stackwalker you're making.
 
-5. Run regression tests on it again.
+5. Run regression tests on it again. Again, it takes 30-40 minutes to run.
 
 6. Compare timings and sizes.
 

--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,9 +14,8 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-# NOTE(willkg): This is just a bit after v0.18.0.
-MINIDUMPREV=1869d3a0
-MINIDUMPREVDATE=2023-10-13
+MINIDUMPREV=v0.20.0
+MINIDUMPREVDATE=2024-01-31
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 

--- a/bin/generate_regression_data.py
+++ b/bin/generate_regression_data.py
@@ -130,7 +130,7 @@ def process_crashid(
 
     # Run stackwalker and append times
     for i in range(NUM_TIMES):
-        click.echo(f"nocache ({i+1}/{NUM_TIMES}) ...")
+        click.echo(f"nocache ({i+1}/{NUM_TIMES}) ... ", nl=False)
         subprocess.run(["rm", "-rf", str(symbolscache)])
         symbolscache.mkdir()
         (symbolscache / "tmp").mkdir()
@@ -146,7 +146,9 @@ def process_crashid(
             crashid=crashid,
         )
         end_time = time.time()
-        row.append(str(int(end_time - start_time)))
+        delta = int(end_time - start_time)
+        click.echo(f"{delta}s")
+        row.append(str(delta))
 
     # Append symbols cache size
     row.append(str(symbolscache_size(str(symbolscache))))
@@ -172,7 +174,7 @@ def process_crashid(
 
     # Run stackwalker and append times
     for i in range(NUM_TIMES):
-        click.echo(f"cache ({i+1}/{NUM_TIMES}) ...")
+        click.echo(f"cache ({i+1}/{NUM_TIMES}) ... ", nl=False)
         start_time = time.time()
         run_mdsw(
             stackwalker=str(stackwalker),
@@ -183,7 +185,9 @@ def process_crashid(
             crashid=crashid,
         )
         end_time = time.time()
-        row.append(str(int(end_time - start_time)))
+        delta = int(end_time - start_time)
+        click.echo(f"{delta}s")
+        row.append(str(delta))
 
     # Append symbols cache size
     row.append(str(symbolscache_size(str(symbolscache))))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 # https://hub.docker.com/_/rust/
-# NOTE(willkg): we want to use an older debian image so that we're not locked
-# into a newer glibc
-FROM rust:1.72.1-bullseye@sha256:6562d50b62366d5b9db92b34c6684fab5bf3b9f627e59a863c9c0675760feed4
+# NOTE(willkg): we want to use bullseye debian image so that we're not locked
+# into a newer glibc which doesn't work with docker in our infrastructure.
+# We can update to a newer debian image once we've moved to GCP.
+FROM rust:1.76.0-bullseye@sha256:b3ec72b36c32f9c2437714354fadf2d05988acd3333699145e0a539c524bde99
 
 ARG groupid=10001
 ARG userid=10001

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 click
+crashstats_tools
 requests
 rich


### PR DESCRIPTION
This improves the regression test code a little, updates the version of rust we use, and updates the stackwalker to v0.20.0.

This picks up the following changes:

```
3581196 (tag: v0.20.0) chore: Release
852af14 Updated cargo-dist configuration
0b3aff9 Updated the release notes for the next version
8e2dae5 Updated ctor to version 0.2
7da12de Updated all the dependencies, this removes a few duplications and picks up some useful fixes
e6b5c2a fix: restore the idx field on thread spans
dd377d1 Remove the dependency on dump_syms
35651c5 Make MmapMinidump static
8d69037 Avoid requiring a dependency on memmap2 to use Minidump<'_, Mmap>
7f38b36 bug-1873529: fix debug id for modules found by code-info lookup
5f31ab7 Update scroll to 0.12
362a4a0 Update memmap2 to 0.9.3
a068902 fmt
05396af fix clippy lints from 1.75.0
99e0590 Use the procfs crate in minidump for parsing linux memory maps. (#812)
7a9ea0b Print the si_code of a Linux signal correctly when it contains a negative code (#911)
43e9781 Add support for additional macOS guard exception types and flavors (#901)
640de21 Interpret Windows error-code correctly even when they're sign-extended. (#894)
c3de84b (tag: v0.19.1) chore: Release
46a9833 Updated the release notes for the next version
f6de402 Remove the MSI installer
aae3c27 Updated all the dependencies to address several mild security issues in some crates
3a60101 (tag: v0.19.0) chore: Release
e92bcec Updated cargo-dist to version 0.4.2
ca0a97d Updated the release notes for the next version
8e7457c Bump the versions of the fuzzing crates
403e1c9 Update symbolic and memmap2, also get rid of crate versions that were yanked
2851131 Add support for the MINIDUMP_HANDLE_DATA_STREAM stream (#885)
9b8dd79 Merge pull request #881 from lissyx/fds
f696691 cargo doc
cc597b6 panic instead of assert as per clippy
de13372 remove debug
a3ff3d7 cargo fmt
8f15e96 cargo insta review pass 2
a18d69d cargo insta review pass 1
7a1533d Fix review comments
055e3d0 Add /proc/PID/limits to produced JSON
6c6edb5 Parsing /proc/PID/limits
b816e2a Remove MozLinuxFDs and add MozLinuxLimits to lib doc
2f99693 Add entries for /proc/self/fd/ and /proc/self/limits
```

Regression tests:

```
$ ./bin/regression_stats.py regr/20240228_093020/ regr/20240228_104301/
 crashid                               run1 time  cache size  output size  run2 time  cache size  output size 
 92917d74-ba56-4598-b4d1-9041d0240228  6          71,812      406,451      13         71,812      406,485     
 feb9eb77-5c28-4101-9336-0acad0240228  25         661,364     484,246      30         661,364     484,280     
 de9edf3c-1182-446a-8a9a-eb5f80240228  26         572,628     156,246      27         572,632     156,280     
 9b8e36e6-a661-4421-b9de-a12c90240228  28         677,680     262,891      21         677,680     262,925     
 a933cab6-9c31-493a-a515-44ac80240228  36         678,896     390,086      29         678,892     413,877     
 b359a929-4228-47a7-a075-f7a760240228  45         685,744     444,317      21         685,744     539,753     
 37987f46-3be5-4e84-8d47-0b3d70240228  30         553,776     212,179      24         553,776     212,213     
 23940e81-ece6-4ddb-a1a8-a2f190240228  5          10,248      579,595      4          10,248      579,629     
 adad7022-7b83-498c-866a-04dc00240228  31         645,588     317,018      35         645,588     332,204     
 e224139e-5697-4d4c-ba5b-e1ea90240228  33         554,312     324,017      23         554,308     324,051     
 ab3dea2e-014c-4c89-a259-ed5be0240228  40         756,596     292,585      44         756,596     292,619     
 ece36fad-afe6-4252-b13b-2835c0240228  48         652,248     1,760,844    28         652,248     1,760,878   
 287f512b-6168-4712-8bf3-aaa980240228  1,001      572,288     168,419      23         572,292     185,740     
 49cddecf-977c-46c0-b1db-bc7de0240228  29         522,296     367,499      22         522,296     367,533     
 4524be50-a670-460f-8c12-22bd90240228  21         532,464     502,635      31         532,460     502,669     
 7d7001a5-968a-4b14-8861-c64aa0240228  29         520,644     198,820      20         520,644     198,854     
 b23b5bba-afb3-4199-88ba-d93f00240228  23         547,104     124,784      49         547,104     124,818     
 552d1743-40c3-4381-9aa0-73cd10240228  23         605,252     387,802      25         605,248     387,836     
 010d4d4a-94b7-4610-9c89-428590240228  22         573,072     302,026      23         573,076     325,582     
```

Timings don't change too much. v0.20.0 adds some new fields to the output, so the output increased in size. Nothing worrying here.