### PR TITLE
bug-1862730: update stackwalker to v0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Patches are manually verified and tested. At some point, we will change this.
 
 # Regression testing
 
+This requires a `CRASHSTATS_API_TOKEN` with the "View Raw Dumps" and "View Personal Identifiable
+Information" permissions.
+
 Create a Python virtual environment and install the requirements from
 `requirements-dev.txt`.
 

--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-MINIDUMPREV=v0.20.0
-MINIDUMPREVDATE=2024-01-31
+MINIDUMPREV=v0.21.0
+MINIDUMPREVDATE=2024-02-28
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@ ARG userid=10001
 
 WORKDIR /app/
 
+RUN apt update && apt install -y python3-venv
+
 RUN update-ca-certificates && \
     groupadd --gid $groupid app && \
     useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home app && \


### PR DESCRIPTION
This also adds python3-venv to the docker config for running regression tests in docker, and adds a comment to the readme about what permissions are needed on the api key to run regression tests.

This picks up the following changes, in particular `3e18614 Use framehop and wholesym rather than symbolic for the local debuginfo symbol provider.` is expected to provide some performance improvement:
```
2611865 (tag: v0.21.0) chore: Release
2f56803 Updated cargo-dist configuration using version 0.11.1
c154dbd Updated the release notes for the next version
52ffeda Updated all the dependencies
58a239c Allow passing the path to a symbol files in --symbols-path
7b28df6 Merge pull request #963 from rust-minidump/dependabot/cargo/framehop-0.9.0
9030821 Merge pull request #955 from lissyx/get-soname
936ca21 Bump framehop from 0.8.0 to 0.9.0
a66b5c5 Merge pull request #957 from rust-minidump/dependabot/cargo/cachemap2-0.3.0
e4c370c Bump cachemap2 from 0.2.0 to 0.3.0
2cf996d Merge pull request #958 from rust-minidump/dependabot/cargo/num-derive-0.4.2
15a3020 Bump num-derive from 0.4.1 to 0.4.2
74c8656 Merge pull request #952 from rust-minidump/dependabot/cargo/time-0.3.34
3649152 Merge pull request #950 from rust-minidump/dependabot/cargo/env_logger-0.11.1
f33622a Merge pull request #948 from rust-minidump/dependabot/cargo/num-traits-0.2.18
bd1959b Bug 1847098 - Parse version number for Elf files
19931a1 Bump num-traits from 0.2.17 to 0.2.18
d4f6c7f Allow compile-time and runtime selection of symbolication in the DebugInfoSymbolProvider.
b5c57e8 Use a trait object to abstract over framehop platforms.
3e18614 Use framehop and wholesym rather than symbolic for the local debuginfo symbol provider.
6714a70 Remove redundant imports
556ebab Bump clap from 4.4.18 to 4.5.0
b66d682 Bump cab from 0.4.1 to 0.5.0
b5d23e8 clippy
4221d28 parse threadinfolist stream
21673cb Validate `stack_memory` once in `walk_stack`
0289d14 Bump time from 0.3.31 to 0.3.34
fe29edb Bump env_logger from 0.10.2 to 0.11.1
a708dec Get `MinidumpModule` before constructing `CfiStackWalker`
631f649 Reduce duplication a bit more
e0e680c Use a constructor for `CfiStackWalker`
5127da5 Finish refactoring all the args
bb2c07d Turn `args` into a ref and thread it through more fns
f87387e Combine all the arguments into a struct
9d1166b Move `stack_memory` unwrapping one up
88153c0 Unwrap `stack_memory` in the outer `get_caller_frame`
78f52e6 Actually just remove the whole `Unwind` trait
a8ebe53 Use AFIT for the `Unwind` trait
34019f0 Fix CI badge
7146857 Remove unnecessary chrono dependency
```
Regression tests:
```
$ ./bin/regression_stats.py regr/20240228_125034 regr/20240228_132110
 crashid                               run1 time  cache size  output size  run2 time  cache size  output size 
 35c511af-61da-4dfa-80f8-ee5c70240228  13         665,892     289,183      12         665,892     289,183     
 c573e751-2bfc-4521-994f-8005d0240228  8          574,512     232,745      4          574,512     232,745     
 9052b62d-a179-44a0-8812-c8b640240228  19         645,584     252,551      255        645,584     252,551     
 3b734776-2785-4a2a-8a4f-eb9d50240228  4          600,952     343,590      4          600,952     343,590     
 0e5126ad-b086-4d3c-b2b9-a86390240228  19         585,720     523,486      9          585,720     523,486     
 a85b2dad-b384-426f-8436-1035f0240228  11         557,404     2,632,282    10         557,404     2,632,282   
 a8073556-4e94-4f55-bdf6-ed04a0240228  7          522,296     259,003      9          522,296     259,003     
 2e1eeb7c-7389-4c0c-a49b-a474b0240228  10         677,348     216,673      8          677,348     216,673     
 f37ede66-b0e5-44b3-a038-51f670240228  5          715,164     246,195      20         715,164     246,195     
 58cca986-e55e-42c1-90eb-5e7f80240228  21         573,168     272,290      25         573,168     272,290     
 59dd77ba-fa74-4d23-b8b8-2d2360240228  87         658,708     210,208      31         658,708     210,208     
 97f05e2a-7eb9-4c86-a8f4-8d3b40240228  10         677,612     390,650      19         677,612     390,650     
 8aa657f5-644e-4181-a2d4-78b6c0240228  5          661,504     365,559      15         661,504     365,559     
 98c79016-4ec5-46e5-aa09-6836a0240228  15         521,772     298,168      8          521,772     298,168     
 cc0c137b-72eb-4525-9456-20b6c0240228  9          521,348     248,955      20         521,348     248,955     
 b9ee2f64-b9d0-455a-8a1d-088a00240228  12         615,200     429,120      13         615,200     429,120     
 b63262f2-8328-4199-b5ab-869270240228  10         773,244     347,599      8          773,244     347,599     
 da8a2d15-643f-4fb5-a590-5dfbd0240228  11         751,240     404,228      10         751,240     404,228     
 fc9a68b6-720f-4b52-bf7a-1518f0240228  251        645,588     264,585      248        645,584     264,585
```
the cache and output sizes are unchanged, and the run times look similar with the exception of the third crash which had a slow run. Only 19 crashes show up in the report because one crash had an error both before and after the change.

before the update it returned:
```
nocache (1/5) ... stackwalker error: ProcessError('stackwalker: stdout:  stderr: ERROR MissingThreadList - Error processing dump: The thread list stream was not found\n')
```

and after the update it returned:
```
nocache (1/5) ... stackwalker error: ProcessError('stackwalker: stdout:  stderr: ERROR Panic - A panic occurred at minidump-stackwalk/src/main.rs:430: need system info: StreamNotFound\n')
```