### PR TITLE
build a stackwalker binary for arm64

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -22,10 +22,16 @@ TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 # Print versions for debugging
 rustc -vV
 
+# Make sure Apple Silicon arch target is installed
+rustup target add aarch64-apple-darwin
+
+# TARGET="x86_64-unknown-linux-gnu"
+TARGET="aarch64-apple-darwin"
+
 # Build the specific version we want of minidump-stackwalk
 echo ">>> compiling minidump-stackwalk sha ${MINIDUMPREV} ${MINIDUMPREVDATE} ..."
 cargo install --locked \
-    --target=x86_64-unknown-linux-gnu \
+    --target=$TARGET \
     --root=./build/ \
     --git https://github.com/rust-minidump/rust-minidump.git \
     --rev $MINIDUMPREV \


### PR DESCRIPTION
While trying to verify https://bugzilla.mozilla.org/show_bug.cgi?id=1888201 in Socorro stage by [fetching/processing/inspecting a crash locally](https://socorro.readthedocs.io/en/latest/dev.html#processing-crashes), I hit an error in `make build`[1]. Based on the error message, I believe I've hit https://github.com/docker/roadmap/issues/384, since `socorro-stackwalk` builds a binary only for the [`x86_64-unknown-linux-gnu` target](https://github.com/mozilla-services/socorro-stackwalk/blob/cd6867c885e32742623acbe0e4e07f47d503b443/bin/build_stackwalker.sh#L28) (i.e. x86_64 architecture), but my dev machine is arm64. I am not sure what could have changed, as I successfully ran the local Socorro stack a month or so ago without issue[2].

I noticed that the `rust-minidump` project provides a binary for [each release](https://github.com/rust-minidump/rust-minidump/releases) for Apple Silicon (arm64 architecture) among other platforms, so I thought I'd try to build a `tar.gz` for that and reference it in [Socorro's `set_up_stackwalker.sh`](https://github.com/mozilla-services/socorro/blob/75d19c3a1cd7d98035c4eb532e1a6e230f6837b6/docker/set_up_stackwalker.sh#L13-L15) to see if that gets `make build` to work.

This is a WIP to test that this approach works. Ideal state is that the `bin/build_stackwalker.sh` script produces binaries for multiple targets and all target binaries are published as part of a single GitHub Release, similar to the [`rust-minidump` project's releases](https://github.com/rust-minidump/rust-minidump/releases).

---------

[1]: `rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2` (or `qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory` if I disable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings). After some research, I learned that `/lib64/ld-linux-x86-64.so.2` is the [dynamic linker](https://en.wikipedia.org/wiki/Dynamic_linker) specified by the binary, and it is for the x86-64 architecture.

[2]: I tried rolling back my Docker Desktop version a few versions back (well past when I remember things working), but I keep getting the same error. I also looked into rolling back my Rosetta version, but that installation is handled by my OS and not configurable AFAICT outside of rolling back my OS version.