### PR TITLE
bug-1924072: update stackwalker to 0.22.2

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-MINIDUMPREV=v0.21.1
-MINIDUMPREVDATE=2024-03-01
+MINIDUMPREV=v0.22.2
+MINIDUMPREVDATE=2024-10-10
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 


### PR DESCRIPTION
This picks up the following changes:

```
rust-minidump$ git log --oneline v0.21.1..v0.22.2
ca0ab4d (HEAD -> main, tag: v0.22.2, origin/main, origin/HEAD) chore: Release
f5e4dda Updated the release notes for the next version
b0dbc1d Updated the yaxpeax-x86 crate to version 2.x
c8d81cc Bump the procfs-core crate to the latest version
5719c4f Bump the framehop crate to the latest version
1796d29 Remove a duplicate version of the cab crate
af1be32 Bump reqwest to version 0.12.x, this removes a lot of duplicated dependencies
0f85e34 Allow non-canonical inconsistency detection for UCOMISS
0a24776 Limit non-canonical inconsistency detection to selected opcodes
de2ceb5 Fix a few broken links in CONTRIBUTING.md
8f0de71 Fix typo
4722ec8 Address feedback from cmartin
c24aa62 Fix snap tests
0bc6194 Remove outdated naming and comments
b8c4b6a Address feedback from afranchuk
06c3ecc Appease clippy
3296d3c Address feedback from gsvelto
4a8423c Remove outdated comments for inconsistency detection output
9c9194e Refactor for better naming and add jcc opcodes for inconsistency detection
a092857 Remove access violation checking for EXCEPTION_STACKOVERFLOW
a358a77 Fix correct handling of rip update for non-canonical crash inconsistency detection
1f12137 Address feedback from cmartin
814f89a Check rip update for non-canonical crash inconsistency detection
e98c662 Fix non-canonical crash inconsistency detection
60466ae Refactor memory accesses and rip update in op_analysis.rs
08429f0 Refactor op_analysis.rs and processor.rs for better style
3dd36fd Fix dead code in CommonOpcode enum
d5f87b3 Add more common opcodes (ADD/SUB, CMP etc) for inconsistent crash detection
3b19984 Add inconsistency detection for non-canonical address crashes
374d7c9 Fix clippy issues
b5e7c7a Add JSON output for inconsistent crash detection
91e9831 Add more common opcodes and implement implicit memory access for inconsistent crash detection
5405f44 Move rip update out of memory accesses
f8573b1 Limit memory access inconsistency detection to common instructions
42d8023 Incorporate more crash reasons for inconsistent crash detection
0df4b62 Redesign inconsistent crash detection skeleton
3ac3dee Address feedback from afranchuk
ad9d39d Add skeleton for inconsitency crash detection of non-memory-access crashes
dc012fb Correct inconsistency detection for exec violation
04b1902 Add more opcodes for deriving memory operation from instructions
06d0a8a Implement basic inconsistent crash detection
bf67ed9 (tag: v0.22.1) chore: Release
7877a8e Fix build & clippy issues
0db7d82 Updated cargo-dist configuration using version 0.22.1
86374a4 Update yanked crates
8e39f68 Updated the release notes for the next version
06a3d4e Appease clippy.
7cf245c Add support for Fat MachO files in the minidump-unwind debuginfo symbol provider.
ec48da2 (tag: v0.22.0) chore: Release
67d92f1 Updated cargo-dist configuration using version 0.17.0
a013416 Updated the release notes for the next version
d1e2010 Update to wholesym 0.7.
b047771 Get memory_map_count directly from stream and rename to be Linux specific
cdd45b5 Rewrite for clippy and revert human snap changes
db21a92 Limit memory_map_count to Linux only
8a75e07 Address feedback from cmartin
ff6ee49 Add reporting of memory map count
a4304d0 Update for json-pretty-unloaded.snap file
9645b2b Update for the .snap files
2ec0e0d Adding thread_id to the minidump-processor/json-schema.md #1008
547615f Adding thread_id to human and json format  #1008
d235cbb Update a number of dependencies to remove some duplicates.
1d87415 Appease clippy
275767a Add empty line in symbol file CFI test
882ac58 Explicitly handle empty lines
f1cd26a Update to framehop 0.12.2.
434c1ac Merge pull request #1006 from BrianShTsoi/deterministic_output
027cf4e Use BTreeMap so that streams are always sorted
bf5415e (tag: v0.21.2) chore: Release
70ac8a4 Updated the release notes for the next version
ddfdeea Updated cargo-dist configuration using version 0.15.0
4b5250e Sort unknown and unimplemented streams for deterministic output
c01c10a Update the locked `backtrace` (used by tokio) to remove duplicate `object` crates.
7080a72 Update to wholesym 0.5.
40a2682 Update framehop and change `object` to have minimal features.
3a7dde8 Impl `Symbol Provider` for `&dyn SymbolProvider`.
```

Regression tests:

```
socorro-stackwalk$ ./bin/regression_stats.py regr/20241014_111806/ regr/20241014_113954/
 crashid                               run1 time  cache size  output size  run2 time  cache size  output size 
 897225de-7673-4e04-9b70-723070241014  7          600,348     313,120      13         600,344     313,565     
 3a0f322f-552f-4fa3-a12b-081230241014  8          613,120     239,557      6          613,120     240,147     
 d07b07ba-568e-44ff-86b7-23df80241014  5          662,048     525,303      4          662,048     526,740     
 59bd99f5-c8d8-40bd-b778-e42e20241014  12         732,776     305,043      4          732,776     305,762     
 ee1ed7ea-6544-4507-9c74-591c20241014  13         715,312     342,249      23         715,312     343,150     
 bb739a2c-e31f-4ec4-a908-cfcdd0241014  2          71,748      310,994      1          71,748      311,943     
 8cca7fd1-34aa-4dba-af94-516310241014  7          620,872     524,757      12         620,872     525,640     
 2d21dde6-20b8-408f-b21c-a4cf10241014  14         615,800     755,706      13         615,800     757,290     
 c1fdc2c6-6ab0-4831-9d70-a0bd90241014  11         617,108     548,613      13         617,108     549,737     
 ca060a9d-85a1-4b97-aa9b-02f340241014  4          123,596     268,949      1          123,596     269,818     
 e88814b7-55f1-4f79-8daa-b230f0241014  19         733,424     1,977,969    8          733,420     1,979,626   
 1734c622-cb90-4e79-96c4-746ff0241014  13         556,284     449,108      12         556,284     450,390     
 ac0d2c72-e9c4-4565-99ec-cdb7d0241014  14         601,252     275,775      4          601,252     276,535     
 fa2cccee-b2ec-40e6-bf8c-e88c00241014  12         546,372     82,509       5          546,368     82,822      
 82de3e2f-aff2-420e-b655-9e0e60241014  10         630,052     600,477      12         630,048     601,788     
 37945147-c305-49a8-8a59-015820241014  12         718,688     268,168      5          718,688     268,926     
 0fb9ee8b-64b3-4835-8bd0-7608e0241014  11         736,776     581,824      11         736,776     582,952     
 d9f9b103-cdae-4253-b2be-9a8680241014  14         691,832     331,299      10         691,832     332,290     
 d9fafebb-5a3f-4864-b843-2b6a30241014  12         600,344     371,247      8          600,344     372,005     
 014a4ece-aeb4-4328-adf6-12ab50241014  7          693,688     284,555      16         693,688     285,215     
 003ddd6f-cb25-427b-944c-536060240726  12         617,040     1,100,352    12         617,044     1,102,514   
 02aae1f4-e9bb-4d66-8cd3-5e2740240726  9          609,632     1,072,674    12         609,636     1,075,215   
 03539d17-79ea-4447-b408-f5e840240726  5          533,812     132,936      10         533,812     133,476     
 04a98b46-7210-4d20-a901-934750240726  10         628,888     950,101      13         628,888     952,131     
 0bb6e931-6265-4e21-8ea3-351830240726  4          520,764     246,276      4          520,764     246,997
```

This picks up changes required for [bug 1918240](https://bugzilla.mozilla.org/show_bug.cgi?id=1918240), and regression test includes 5 extra crash ids from that bug