### PR TITLE
OBS-270: Upgrade to Debian bookworm and Rust 1.84.1.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,5 @@
 # https://hub.docker.com/_/rust/
-# NOTE(willkg): we want to use bullseye debian image so that we're not locked
-# into a newer glibc which doesn't work with docker in our infrastructure.
-# We can update to a newer debian image once we've moved to GCP.
-FROM rust:1.76.0-bullseye@sha256:b3ec72b36c32f9c2437714354fadf2d05988acd3333699145e0a539c524bde99
+FROM rust:1.84.1-bookworm@sha256:738ae99a3d75623f41e6882566b4ef37e38a9840244a47efd4a0ca22e9628b88
 
 ARG groupid=10001
 ARG userid=10001


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/OBS-270

Here are the regression test results:
```
$ ./bin/regression_stats.py regr/20250206_163210/ regr/20250206_153118/
 crashid                               run1 best time  cache size  output size  run2 best time  cache size  output size 
 4d94459a-84ba-42bb-8515-b98380250206  0               12          15,561       0               12          15,561      
 4c324da4-d035-4c8d-843c-0aae60250206  0               12          15,561       0               12          15,561      
 becdab7d-1eeb-49d0-97d8-2792f0250206  26              629,628     370,382      16              629,624     370,382     
 ea9747af-1f48-499d-904c-704d50250206  23              636,316     355,979      15              636,320     355,979     
 cac86f89-4bb8-4e3c-b173-711330250206  27              661,524     66,503       17              661,520     66,503      
 3ceef184-9d01-45b9-b55f-00cbe0250206  23              634,692     328,516      15              634,688     328,516     
 9de3ceb9-1a3c-4d3e-ac9c-a8ab30250206  25              764,180     257,867      7               764,180     257,867     
 90d196d5-a930-452f-a102-866240250206  24              694,508     277,247      15              694,512     277,247     
 5e734e7f-d7b4-46fe-94be-6185b0250206  29              765,444     320,935      18              765,444     320,935     
 353d41c1-7af5-4205-9a95-9ea510250206  21              657,548     678,830      15              657,544     678,830     
 a205d92d-f147-4b40-97eb-6147a0250206  23              700,572     201,218      18              700,572     201,218     
 709296f4-5298-4c00-8d3d-5b0b40250206  23              737,544     599,242      19              737,544     599,242     
 60989445-2edc-4a24-850d-f23c30250206  23              601,536     342,401      15              601,532     342,401     
 a3bb738c-e6c6-49bd-9d4c-0d60f0250206  26              616,316     312,082      16              616,312     312,082     
 38c083ac-09ee-4051-bf48-0d0c90250206  29              825,476     424,029      25              825,476     424,029     
 330a88a8-9bce-4e56-bca5-355200250206  13              634,952     308,923      16              634,948     308,923     
 b3297727-7846-4b85-b050-b71550250206  15              616,316     305,010      18              616,316     305,010     
 d1565628-909e-4b5d-8eb1-29ef00250206  13              594,224     294,191      7               594,220     294,191     
 909cc9a2-de1e-4e0e-a1e7-6cf430250206  15              762,820     481,943      20              762,816     481,943     
```
I ran the tests for the new version first, which is why the time on the command line are the wrong way around. The left column is the old version, the right column the new version. I'm not sure to what the degree the results were influenced by the work I continued to do on my laptop while the tests were running.