### PR TITLE
Use apparent size to report symbols cache size.

### DIFF
--- a/bin/generate_regression_data.py
+++ b/bin/generate_regression_data.py
@@ -74,6 +74,7 @@ def symbolscache_size(symbolscache):
     ret = subprocess.run(
         [
             "du",
+            "--apparent-size",
             "-ks",
             symbolscache,
         ],


### PR DESCRIPTION
We noticed in #18 that the symbols cache size reported by the regression tests is prone to variance causde by filesystem behaviour (e.g. delayed allocation and varying extent tree layouts in ext4). For the regression tests we are interested in the file sizes in bytes rather than the number of blocks the filesystem chose to allocate for a file, so this PR changes the `du` invocation accordingly.

The GNU version of `du` has supported the `--apparent-size` parameter for a long time, but it's not part of POSIX. Chances are it's not supported on macos, which probably means we don't want to merge this PR.

@relud Could you check whether this works on macOS?