### PR TITLE
Compute symbols cache size in bytes without using `du`.

### DIFF
--- a/bin/generate_regression_data.py
+++ b/bin/generate_regression_data.py
@@ -66,26 +66,12 @@ def fetch_data(crashdata_dir, crashid):
 
 
 def symbolscache_size(symbolscache):
-    """Return size of symbols cache directory.
-
-    Uses "du" command.
-
-    """
-    ret = subprocess.run(
-        [
-            "du",
-            "-ks",
-            symbolscache,
-        ],
-        capture_output=True,
+    """Return size of symbols cache directory in bytes."""
+    return sum(
+        os.path.getsize(os.path.join(root, file))
+        for root, dirs, files in os.walk(symbolscache)
+        for file in files
     )
-    if ret.returncode != 0:
-        stdout = ret.stdout.decode("utf-8")
-        stderr = ret.stderr.decode("utf-8")
-        raise ProcessError(f"du: stdout: {stdout} stderr: {stderr}")
-
-    output = ret.stdout.decode("utf-8")
-    return int(output.split("\t")[0])
 
 
 def run_mdsw(


### PR DESCRIPTION
We noticed in https://github.com/mozilla-services/socorro-stackwalk/pull/18 that the symbols cache size reported by the regression tests is prone to variance causde by filesystem behaviour (e.g. delayed allocation and varying extent tree layouts in ext4). For the regression tests we are interested in the file sizes in bytes rather than the number of blocks the filesystem chose to allocate for a file.

This PR computes the symbols cache size as the sum of the sizes of all files in the cache directory, without calling `du`. This returns a consistent size independent of filesystem behaviour.