### PR TITLE
bug-1954596: update stackwalker to v0.25.0

### DIFF
--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -14,8 +14,8 @@
 set -euo pipefail
 
 # From: https://github.com/rust-minidump/rust-minidump
-MINIDUMPREV=v0.22.2
-MINIDUMPREVDATE=2024-10-10
+MINIDUMPREV=v0.25.0
+MINIDUMPREVDATE=2025-03-19
 
 TARFILE="socorro-stackwalker.${MINIDUMPREVDATE}.${MINIDUMPREV}.tar.gz"
 


### PR DESCRIPTION
This updates the stackwalker from v0.22.2 to v0.25.0. It picks up a bunch of changes including parsing of soft errors from the minidump-writer.

I don't see any indications of hard regressions. The output size is slightly larger for every crash report as expected because of the additional output.

```
$ uv run --with click --with rich bin/regression_stats.py regr/20250320_140751/ regr/20250320_142957/
Installed 5 packages in 16ms
 crashid                               run1 best time  cache size   output size  run2 best time  cache size   output size
 7b086f4c-4776-4c89-a73d-bc50b0250320  10              533,699,445  200,439      10              533,699,445  200,458
 4a82f729-5fc2-4abc-a4a2-322d90250320  0               0            24,235       0               0            24,254
 bcd254ce-cd03-4915-b7de-0ec570250320  10              617,143,345  325,605      10              617,143,345  325,624
 2723d7ec-922c-4190-8a09-d83500250320  9               609,702,019  261,033      10              609,702,019  261,052
 e16d78c3-d78c-4903-97cf-12ef90250320  10              711,404,380  1,664,806    10              711,404,380  1,664,825
 78cf7e7d-32fb-45ac-8bcc-079870250320  10              686,608,484  239,838      10              686,608,484  239,857
 767d78b0-cc9b-4a69-aaaa-076f20250320  11              821,822,162  327,192      11              821,822,162  327,211
 e02ef41f-e946-4246-a61c-c69b10250320  10              687,012,268  215,880      11              687,012,268  215,899
 caf2f01a-c99e-4703-ae86-e4d1c0250320  8               635,727,166  463,624      9               635,727,166  463,643
 17a650a4-8802-49fd-a5a4-0e57b0250320  3               248,476,145  310,243      4               248,476,145  310,262
```